### PR TITLE
DSTBACK-5354 fix: Id to allow string, number and null for gojsonrpc library

### DIFF
--- a/v1/server.go
+++ b/v1/server.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -19,14 +20,14 @@ type responseError struct {
 }
 
 type requestData struct {
-	Id      string          `json:"id"`
+	Id      json.RawMessage `json:"id"`
 	Version string          `json:"jsonrpc"`
 	Params  json.RawMessage `json:"params"`
 	Method  string          `json:"method"`
 }
 
 type responseData struct {
-	Id      string         `json:"id,omitempty"`
+	Id      json.RawMessage `json:"id,omitempty"`
 	Version string         `json:"jsonrpc"`
 	Result  interface{}    `json:"result,omitempty"`
 	Error   *responseError `json:"error,omitempty"`
@@ -257,7 +258,7 @@ func (service *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		noRequests := len(requests)
 
-		known_ids := []string{}
+		known_ids := []json.RawMessage{}
 
 	REQUESTS_LOOP:
 		for _, request := range requests {
@@ -266,7 +267,7 @@ func (service *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			response.Version = "2.0"
 			responses = append(responses, response)
 			for _, b := range known_ids {
-				if request.Id == b {
+				if bytes.Equal(request.Id, b) {
 					response.Error = &responseError{
 						Code:    CodeInvalidRequest,
 						Message: "The 'id' element is not unique",

--- a/v1/server_test.go
+++ b/v1/server_test.go
@@ -202,6 +202,38 @@ func TestServiceServeHTTP(t *testing.T) {
 
 			})
 		})
+		Convey("Given an http request containing a JSONRPC request with a numeric id", func() {
+			request := http.Request{
+				Method: "POST",
+				Body: fakeBody{bytes.NewBufferString(`{
+					"id": 42,
+					"jsonrpc": "2.0",
+					"method": "FooBar",
+					"params": {
+						"foo": "I LIKE BEANS",
+						"bar": 10
+					}
+				}`)},
+			}
+
+			Convey("When the http request is served", func() {
+				response := fakeResponse{headers: map[string][]string{}}
+				service.ServeHTTP(&response, &request)
+
+				Convey("Then the response should have the 200 status code", func() {
+					So(response.status, ShouldEqual, http.StatusOK)
+				})
+
+				Convey("Then the response should have the json content type", func() {
+					So(response.Header().Get("Content-Type"), ShouldEqual, "application/json")
+				})
+
+				Convey("Then the response should echo the numeric id", func() {
+					expected := `{"id":42,"jsonrpc":"2.0","result":{"I LIKE BEANS":"foo","bar":"I LIKE 10 BARS"}}`
+					So(response.Body(), ShouldEqual, expected)
+				})
+			})
+		})
 		Convey("Given an http request containing multiple JSONRPC requests", func() {
 			request := http.Request{
 				Method: "POST",


### PR DESCRIPTION
This fixes [DSTBACK-5354](https://accesso.atlassian.net/browse/DSTBACK-5354)

[DSTBACK-5354]: https://accesso.atlassian.net/browse/DSTBACK-5354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ